### PR TITLE
Update _app.js

### DIFF
--- a/nextjs/pages/_app.js
+++ b/nextjs/pages/_app.js
@@ -23,8 +23,18 @@ if (!TrackJS.isInstalled()) {
   });
 }
 
-function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+class MyApp extends App {
+
+  componentDidCatch(error, errorInfo) {
+    TrackJS.track(error);
+    this.setState({ error });
+    // Anything else you want to do with the error.
+  }
+
+  render() {
+    const { Component, pageProps } = this.props;
+    return <Component {...pageProps} />
+  }
 }
 
 export default MyApp;

--- a/nextjs/pages/_app.js
+++ b/nextjs/pages/_app.js
@@ -27,11 +27,4 @@ function MyApp({ Component, pageProps }) {
   return <Component {...pageProps} />
 }
 
-// Standard React extension point for capturing errors.
-MyApp.componentDidCatch = (error, errorInfo) => {
-  TrackJS.track(error);
-  this.setState({ error });
-  // Anything else you want to do with the error.
-}
-
 export default MyApp;


### PR DESCRIPTION
ComponentDidCatch doesn't exist when using a functional component. And the npm packages that you suggest we use, `trackjs` and `trackjs-node` seem to track errors without this.

If you were using class component for the app, then your code might work:
```
class MyApp extends App {
  render() {
    const { Component, pageProps } = this.props;
    return <Component {...pageProps} />;
  }
}

MyApp.componentDidCatch = (error, errorInfo) => {
  TrackJS.track(error);
  this.setState({ error });
  // Anything else you want to do with the error.
}
```

Since it is idiomatic to use a functional component for the Next.js App component, we should remove the `componentDidCatch` entirely or perhaps mention it in a comment instead.